### PR TITLE
Fix passwordGen digit inclusion

### DIFF
--- a/passwordGen.py
+++ b/passwordGen.py
@@ -1,5 +1,7 @@
 import random
-potentialKeys = 'abcdefghijklmnopqrstuvwxyz124567890@;#~/><'
+# Include all digits 0 through 9 so generated passwords can use any decimal
+# digit. The original string omitted the digit '3'.
+potentialKeys = 'abcdefghijklmnopqrstuvwxyz1234567890@;#~/><'
 
 def getLength():
     try:


### PR DESCRIPTION
## Summary
- expand `potentialKeys` to include the missing digit `3`

## Testing
- `python -m py_compile passwordGen.py`


------
https://chatgpt.com/codex/tasks/task_e_6845de723f0c83278325b38ac4940b79